### PR TITLE
Added network get_info api call

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -138,6 +138,13 @@ namespace graphene { namespace app {
     {
     }
 
+    fc::variant network_node_api::get_info() const
+    {
+        fc::mutable_variant_object result = _app.p2p_node()->network_get_info();
+        result["connection_count"] = _app.p2p_node()->get_connection_count();
+        return result;
+    }
+
     void network_node_api::add_node(const fc::ip::endpoint& ep)
     {
        _app.p2p_node()->add_node(ep);

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -133,6 +133,11 @@ namespace graphene { namespace app {
          network_node_api(application& a);
 
          /**
+          * @brief Return general network information, such as p2p port
+          */
+         fc::variant get_info() const;
+
+         /**
           * @brief add_node Connect to a new peer
           * @param ep The IP/Port of the peer to connect to
           */
@@ -204,6 +209,7 @@ FC_API(graphene::app::network_broadcast_api,
        (broadcast_block)
      )
 FC_API(graphene::app::network_node_api,
+       (get_info)
        (add_node)
        (get_connected_peers)
      )


### PR DESCRIPTION
I need some of this information in order for my monitoring tools to work properly. Nothing earth-shattering here, just exposed the method as a network RPC call. I did add the number of connections in that result, too, as it feels like it belongs here instead of in a separate call (in 0.9.x it was available under info['network_num_connections'])
