### PR TITLE
Api calls for #339: needed api calls (mostly network) for supporting bts_tools

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -155,7 +155,22 @@ namespace graphene { namespace app {
 
     std::vector<net::peer_status> network_node_api::get_connected_peers() const
     {
-      return _app.p2p_node()->get_connected_peers();
+       return _app.p2p_node()->get_connected_peers();
+    }
+
+    std::vector<net::potential_peer_record> network_node_api::get_potential_peers() const
+    {
+       return _app.p2p_node()->get_potential_peers();
+    }
+
+    fc::variant_object network_node_api::get_advanced_node_parameters() const
+    {
+       return _app.p2p_node()->get_advanced_node_parameters();
+    }
+
+    void network_node_api::set_advanced_node_parameters(const fc::variant_object& params)
+    {
+       return _app.p2p_node()->set_advanced_node_parameters(params);
     }
 
     fc::api<network_broadcast_api> login_api::network_broadcast()const

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -141,11 +141,11 @@ namespace graphene { namespace app {
     {
     }
 
-    fc::variant network_node_api::get_info() const
+    fc::variant_object network_node_api::get_info() const
     {
-        fc::mutable_variant_object result = _app.p2p_node()->network_get_info();
-        result["connection_count"] = _app.p2p_node()->get_connection_count();
-        return result;
+       fc::mutable_variant_object result = _app.p2p_node()->network_get_info();
+       result["connection_count"] = _app.p2p_node()->get_connection_count();
+       return result;
     }
 
     void network_node_api::add_node(const fc::ip::endpoint& ep)

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -149,8 +149,26 @@ namespace graphene { namespace app {
 
          /**
           * @brief Get status of all current connections to peers
-           */
+          */
          std::vector<net::peer_status> get_connected_peers() const;
+
+         /**
+          * @brief Get advanced node parameters, such as desired and max
+          *        number of connections
+          */
+         fc::variant_object get_advanced_node_parameters() const;
+
+         /**
+          * @brief Set advanced node parameters, such as desired and max
+          *        number of connections
+          * @param params a JSON object containing the name/value pairs for the parameters to set
+          */
+         void set_advanced_node_parameters(const fc::variant_object& params);
+
+         /**
+          * @brief Return list of potential peers
+          */
+         std::vector<net::potential_peer_record> get_potential_peers() const;
 
       private:
          application& _app;
@@ -217,6 +235,9 @@ FC_API(graphene::app::network_node_api,
        (get_info)
        (add_node)
        (get_connected_peers)
+       (get_potential_peers)
+       (get_advanced_node_parameters)
+       (set_advanced_node_parameters)
      )
 FC_API(graphene::app::login_api,
        (login)

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -139,7 +139,7 @@ namespace graphene { namespace app {
          /**
           * @brief Return general network information, such as p2p port
           */
-         fc::variant get_info() const;
+         fc::variant_object get_info() const;
 
          /**
           * @brief add_node Connect to a new peer

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -274,6 +274,10 @@ class wallet_api
       fc::ecc::private_key derive_private_key(const std::string& prefix_string, int sequence_number) const;
 
       variant                           info();
+      /** Returns info such as client version, git version of graphene/fc, version of boost, openssl.
+       * @returns compile time info and client and dependencies versions
+       */
+      variant_object                    about() const;
       optional<signed_block_with_info>    get_block( uint32_t num );
       /** Returns the number of accounts registered on the blockchain
        * @returns the number of registered accounts
@@ -1462,6 +1466,7 @@ FC_API( graphene::wallet::wallet_api,
         (help)
         (gethelp)
         (info)
+        (about)
         (begin_builder_transaction)
         (add_operation_to_builder_transaction)
         (replace_operation_in_builder_transaction)


### PR DESCRIPTION
I added the following api calls:
- witness network api calls: `get_advanced_node_parameters`, `set_advanced_node_parameters`, `get_potiential_peers`
- wallet api call: `about`

Code for `about` was ported from bitshares 0.9.x, with the difference that:
- I couldn't find `BLOCKCHAIN_NAME` and `BLOCKCHAIN_DESCRIPTION` in graphene, so they are not included
- I removed the jenkins build number, not sure if this is still in use or not. I can add those back easily

This pull request doesn't include the `blockchain_get_witness_slot_records` or the `network_set_allowed_peers` calls, I need to investigate more if they are required, and if so, will open a new issue for it at a later stage.
