### PR TITLE
Fix for #557: check BTC/PTS addresses on balance import

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3443,10 +3443,17 @@ vector< signed_transaction > wallet_api_impl::import_balance( string name_or_id,
       {
          optional< private_key_type > key = wif_to_key( wif_key );
          FC_ASSERT( key.valid(), "Invalid private key" );
-         addrs.push_back( key->get_public_key() );
+         fc::ecc::public_key pk = key->get_public_key();
+         addrs.push_back( pk );
          keys[addrs.back()] = *key;
-         pts_address pts( key->get_public_key() );
-         addrs.push_back( pts );
+         // see chain/balance_evaluator.cpp
+         addrs.push_back( pts_address( pk, false, 56 ) );
+         keys[addrs.back()] = *key;
+         addrs.push_back( pts_address( pk, true, 56 ) );
+         keys[addrs.back()] = *key;
+         addrs.push_back( pts_address( pk, false, 0 ) );
+         keys[addrs.back()] = *key;
+         addrs.push_back( pts_address( pk, true, 0 ) );
          keys[addrs.back()] = *key;
       }
    }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3445,6 +3445,9 @@ vector< signed_transaction > wallet_api_impl::import_balance( string name_or_id,
          FC_ASSERT( key.valid(), "Invalid private key" );
          addrs.push_back( key->get_public_key() );
          keys[addrs.back()] = *key;
+         pts_address pts( key->get_public_key() );
+         addrs.push_back( pts );
+         keys[addrs.back()] = *key;
       }
    }
 


### PR DESCRIPTION
This patch simple makes the cli_wallet check sharedrop addresses based on BTC/PTS keys in addition to BTS addresses.
