### PR TITLE
Remove unnecessariy warning (issue #584)

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -235,10 +235,6 @@ fc::variants database_api_impl::get_objects(const vector<object_id_type>& ids)co
          this->subscribe_to_item( id );
       }
    }
-   else
-   {
-      elog( "getObjects without subscribe callback??" );
-   }
 
    fc::variants result;
    result.reserve(ids.size());


### PR DESCRIPTION
This warning is not need and "unpleasant" if you want to simply get data from the witness node via websocket connection but don't need notifications.  (issue #584)
