### PR TITLE
Resove #651: Make add_secondary_index return index

### DIFF
--- a/libraries/db/include/graphene/db/index.hpp
+++ b/libraries/db/include/graphene/db/index.hpp
@@ -165,7 +165,7 @@ namespace graphene { namespace db {
          void on_modify( const object& obj );
 
          template<typename T>
-         void add_secondary_index()
+         T* add_secondary_index()
          {
             _sindex.emplace_back( new T() );
             return static_cast<T*>(_sindex.back().get());

--- a/libraries/db/include/graphene/db/index.hpp
+++ b/libraries/db/include/graphene/db/index.hpp
@@ -168,6 +168,7 @@ namespace graphene { namespace db {
          void add_secondary_index()
          {
             _sindex.emplace_back( new T() );
+            return static_cast<T*>(_sindex.back().get());
          }
 
          template<typename T>


### PR DESCRIPTION
A pointer to the newly created index object is now returned.
