### PR TITLE
Add compile-time sanity check to generic_index

### DIFF
--- a/libraries/db/include/graphene/db/generic_index.hpp
+++ b/libraries/db/include/graphene/db/generic_index.hpp
@@ -80,6 +80,8 @@ namespace graphene { namespace chain {
 
          virtual const object* find( object_id_type id )const override
          {
+            static_assert(std::is_same<typename MultiIndexType::key_type, object_id_type>::value,
+                          "First index of MultiIndexType MUST be object_id_type!");
             auto itr = _indices.find( id );
             if( itr == _indices.end() ) return nullptr;
             return &*itr;


### PR DESCRIPTION
generic_index::find fails at runtime if the boost multi_index_container's first index is not an index of object_id_type, and the cause of this failure is nonobvious from the error message. This compile-time check will fail if any generic_index is created around a multi_index_container whose first index is not an index on object_id_type, with a helpful error message explaining the problem, so no one else will ever have to debug this issue. :)
